### PR TITLE
Updated extension to reflect gnome shell api changes.

### DIFF
--- a/extension/extension.js.in
+++ b/extension/extension.js.in
@@ -246,7 +246,7 @@ AnimatedIcon.prototype = {
         this._timeoutId = 0;
         this._i = 0;
         this._animations = St.TextureCache.get_default().load_sliced_image (global.datadir + '/theme/' + name, size, size);
-        this.actor.set_child(this._animations);
+        this.actor.add_actor(this._animations);
     },
 
     _update: function() {
@@ -376,7 +376,7 @@ MyAppMenuButton.prototype = {
         this._targetApp = null;
 
         let bin = new St.Bin({ name: 'appMenu' });
-        this.actor.set_child(bin);
+        this.actor.add_actor(bin);
 
         this.actor.reactive = false;
         this._targetIsCurrent = false;
@@ -417,7 +417,9 @@ MyAppMenuButton.prototype = {
 
         let tracker = Shell.WindowTracker.get_default();
         tracker.connect('notify::focus-app', Lang.bind(this, this._sync));
-        tracker.connect('app-state-changed', Lang.bind(this, this._onAppStateChanged));
+
+        let app_system = Shell.AppSystem.get_default();
+        app_system.connect('app-state-changed', Lang.bind(this, this._onAppStateChanged));
 
         global.window_manager.connect('switch-workspace', Lang.bind(this, this._sync));
 
@@ -676,7 +678,7 @@ MyAppMenuButton.prototype = {
         _showHello('hello:' + GlobalMenu.meta_window_get_xwindow(window));
     },
 
-    _onAppStateChanged: function(tracker, app) {
+    _onAppStateChanged: function(app_system, app) {
         let state = app.state;
         if (state != Shell.AppState.STARTING) {
             this._startingApps = this._startingApps.filter(function(a) {
@@ -775,13 +777,25 @@ function _showHello(mytext) {
 	Mainloop.timeout_add(3000, function () { text.destroy(); });
 }
 
-function main() {
-    var leftChildren = Main.panel._leftBox.get_children_list();
-    var oldAppMenuButton = leftChildren[leftChildren.length - 1];
-    Main.panel._leftBox.remove_actor(oldAppMenuButton);
-    oldAppMenuButton.destroy();
+let oldAppMenuButton;
+let button;
 
-    var button = new MyAppMenuButton();
-    Main.panel._leftBox.add(button.actor);
-    Main.panel._menus.addMenu(button.menu);
+function init() {
+    let leftChildren = Main.panel._leftBox.get_children_list();
+    oldAppMenuButton = leftChildren[leftChildren.length - 1];
+}
+
+function enable() {
+  Main.panel._leftBox.remove_actor(oldAppMenuButton);
+
+  button = new MyAppMenuButton();
+  Main.panel._leftBox.add(button.actor);
+  Main.panel._menus.addMenu(button.menu);
+}
+
+function disable() {
+  Main.panel._menus.removeMenu(button.menu);
+  button.destroy();
+
+  Main.panel._leftBox.add(oldAppMenuButton);
 }

--- a/extension/metadata.json
+++ b/extension/metadata.json
@@ -1,1 +1,1 @@
-{"shell-version": ["3.0.2"], "uuid": "GlobalMenu@globalmenu.org", "name": "GlobalMenu", "description": "Global Menu for Gnome 3.0"}
+{"shell-version": ["3.1.91", "3.1.92"], "uuid": "GlobalMenu@globalmenu.org", "name": "GlobalMenu", "description": "Global Menu for Gnome 3.0"}


### PR DESCRIPTION
Quick & dirty patch to make the extension work on gnome shell 3.1.91, 3.1.92 (and hopefully 3.2).
metadata.json will need to be updated again when 3.2 will come out.
